### PR TITLE
Expose dataset reduce operations

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -13,7 +13,7 @@ from xarray.core.combine import merge
 from xarray.core import dtypes, utils
 from xarray.core.common import DataWithCoords
 from xarray.core.arithmetic import DatasetArithmetic
-from xarray.core.ops import NUM_BINARY_OPS, NUMPY_SAME_METHODS, REDUCE_METHODS, NAN_REDUCE_METHODS, NAN_CUM_METHODS
+from xarray.core.ops import REDUCE_METHODS, NAN_REDUCE_METHODS, NAN_CUM_METHODS
 
 from .treenode import TreeNode, PathType, _init_single_treenode
 


### PR DESCRIPTION
A WIP attempt to get operations like `*` and `+` working on `DatasetNode` objects.

Idea is to copy the pattern used to add these operators to `xarray.Dataset`, where `Dataset` inherits from `DatasetArithmetic`. 

`DatasetArithmetic` itself inherits from about 5 different Mixin classes, which I don't particularly want to regenerate, especially as `DatasetOpsMixin` is generated by templating in xarray. Here we instead just want to take the methods defined on `DatasetArithmetic` and decorate them with `map_over_subtree`, to get a `DataTreeArithmetic` object to inherit from.

Problem is at the moment I'm getting errors like this:

```
>       result = dt * dt
E       TypeError: unsupported operand type(s) for *: 'DatasetNode' and 'DatasetNode'
```

I don't understand why this is happening because `__mul__` and `__rmul__` are definitely defined on the `dt` objects. (Could it be because those methods get defined only once the object instance has been created, and not when the class is defined?)