### PR TITLE
Replace DataTree init method with from_dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The approach used here is based on benbovy's [`DatasetNode` example](https://gis
 <img src="https://user-images.githubusercontent.com/35968931/130657849-577faa00-1b8b-4e33-a45c-4f389ce325b2.png" alt="drawing" width="500"/>
 
 You can create a `DataTree` object in 3 ways:
-1) Load from a netCDF file that has groups via `open_datatree()`,
-2) Using the init method of `DataTree`, which accepts a nested dictionary of Datasets,
-3) Manually create individual nodes with `DataNode()` and specify their relationships to each other, either by setting `.parent` and `.chlldren` attributes, or through `__get/setitem__` access, e.g.
-`dt['path/to/node'] = xr.Dataset()`
+1) Load from a netCDF file (or Zarr store) that has groups via `open_datatree()`.
+2) Using the init method of `DataTree`, which creates an individual node.
+  You can then specify the nodes' relationships to one other, either by setting `.parent` and `.chlldren` attributes,
+  or through `__get/setitem__` access, e.g. `dt['path/to/node'] = xr.Dataset()`.
+3) Create a tree from a dictionary of paths to datasets using `DataTree.from_dict()`.

--- a/datatree/__init__.py
+++ b/datatree/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 # Ignoring F401: imported but unused
-from .datatree import DataNode, DataTree
+from .datatree import DataTree
 from .io import open_datatree
 from .mapping import map_over_subtree

--- a/datatree/io.py
+++ b/datatree/io.py
@@ -73,7 +73,7 @@ def _open_datatree_netcdf(filename: str, **kwargs) -> DataTree:
 
     with ncDataset(filename, mode="r") as ncds:
         ds = open_dataset(filename, **kwargs).pipe(_ds_or_none)
-        tree_root = DataTree(data_objects={"root": ds})
+        tree_root = DataTree.from_dict(data_objects={"root": ds})
         for key in _iter_nc_groups(ncds):
             tree_root[key] = open_dataset(filename, group=key, **kwargs).pipe(
                 _ds_or_none
@@ -86,7 +86,7 @@ def _open_datatree_zarr(store, **kwargs) -> DataTree:
 
     with zarr.open_group(store, mode="r") as zds:
         ds = open_dataset(store, engine="zarr", **kwargs).pipe(_ds_or_none)
-        tree_root = DataTree(data_objects={"root": ds})
+        tree_root = DataTree.from_dict(data_objects={"root": ds})
         for key in _iter_zarr_groups(zds):
             try:
                 tree_root[key] = open_dataset(

--- a/datatree/mapping.py
+++ b/datatree/mapping.py
@@ -208,7 +208,9 @@ def map_over_subtree(func):
                     output_node_data = None
                 out_tree_contents[p] = output_node_data
 
-            new_tree = DataTree(name=first_tree.name, data_objects=out_tree_contents)
+            new_tree = DataTree.from_dict(
+                name=first_tree.name, data_objects=out_tree_contents
+            )
             result_trees.append(new_tree)
 
         # If only one result then don't wrap it in a tuple

--- a/datatree/tests/test_dataset_api.py
+++ b/datatree/tests/test_dataset_api.py
@@ -2,7 +2,7 @@ import numpy as np
 import xarray as xr
 from xarray.testing import assert_equal
 
-from datatree import DataNode
+from datatree import DataTree
 
 from .test_datatree import assert_tree_equal, create_test_datatree
 
@@ -11,52 +11,52 @@ class TestDSMethodInheritance:
     def test_dataset_method(self):
         # test root
         da = xr.DataArray(name="a", data=[1, 2, 3], dims="x")
-        dt = DataNode("root", data=da)
+        dt = DataTree("root", data=da)
         expected_ds = da.to_dataset().isel(x=1)
         result_ds = dt.isel(x=1).ds
         assert_equal(result_ds, expected_ds)
 
         # test descendant
-        DataNode("results", parent=dt, data=da)
+        DataTree("results", parent=dt, data=da)
         result_ds = dt.isel(x=1)["results"].ds
         assert_equal(result_ds, expected_ds)
 
     def test_reduce_method(self):
         # test root
         da = xr.DataArray(name="a", data=[False, True, False], dims="x")
-        dt = DataNode("root", data=da)
+        dt = DataTree("root", data=da)
         expected_ds = da.to_dataset().any()
         result_ds = dt.any().ds
         assert_equal(result_ds, expected_ds)
 
         # test descendant
-        DataNode("results", parent=dt, data=da)
+        DataTree("results", parent=dt, data=da)
         result_ds = dt.any()["results"].ds
         assert_equal(result_ds, expected_ds)
 
     def test_nan_reduce_method(self):
         # test root
         da = xr.DataArray(name="a", data=[1, 2, 3], dims="x")
-        dt = DataNode("root", data=da)
+        dt = DataTree("root", data=da)
         expected_ds = da.to_dataset().mean()
         result_ds = dt.mean().ds
         assert_equal(result_ds, expected_ds)
 
         # test descendant
-        DataNode("results", parent=dt, data=da)
+        DataTree("results", parent=dt, data=da)
         result_ds = dt.mean()["results"].ds
         assert_equal(result_ds, expected_ds)
 
     def test_cum_method(self):
         # test root
         da = xr.DataArray(name="a", data=[1, 2, 3], dims="x")
-        dt = DataNode("root", data=da)
+        dt = DataTree("root", data=da)
         expected_ds = da.to_dataset().cumsum()
         result_ds = dt.cumsum().ds
         assert_equal(result_ds, expected_ds)
 
         # test descendant
-        DataNode("results", parent=dt, data=da)
+        DataTree("results", parent=dt, data=da)
         result_ds = dt.cumsum()["results"].ds
         assert_equal(result_ds, expected_ds)
 
@@ -65,11 +65,11 @@ class TestOps:
     def test_binary_op_on_int(self):
         ds1 = xr.Dataset({"a": [5], "b": [3]})
         ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
-        dt = DataNode("root", data=ds1)
-        DataNode("subnode", data=ds2, parent=dt)
+        dt = DataTree("root", data=ds1)
+        DataTree("subnode", data=ds2, parent=dt)
 
-        expected_root = DataNode("root", data=ds1 * 5)
-        expected_descendant = DataNode("subnode", data=ds2 * 5, parent=expected_root)
+        expected_root = DataTree("root", data=ds1 * 5)
+        expected_descendant = DataTree("subnode", data=ds2 * 5, parent=expected_root)
         result = dt * 5
 
         assert_equal(result.ds, expected_root.ds)
@@ -78,12 +78,12 @@ class TestOps:
     def test_binary_op_on_dataset(self):
         ds1 = xr.Dataset({"a": [5], "b": [3]})
         ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
-        dt = DataNode("root", data=ds1)
-        DataNode("subnode", data=ds2, parent=dt)
+        dt = DataTree("root", data=ds1)
+        DataTree("subnode", data=ds2, parent=dt)
         other_ds = xr.Dataset({"z": ("z", [0.1, 0.2])})
 
-        expected_root = DataNode("root", data=ds1 * other_ds)
-        expected_descendant = DataNode(
+        expected_root = DataTree("root", data=ds1 * other_ds)
+        expected_descendant = DataTree(
             "subnode", data=ds2 * other_ds, parent=expected_root
         )
         result = dt * other_ds
@@ -94,11 +94,11 @@ class TestOps:
     def test_binary_op_on_datatree(self):
         ds1 = xr.Dataset({"a": [5], "b": [3]})
         ds2 = xr.Dataset({"x": [0.1, 0.2], "y": [10, 20]})
-        dt = DataNode("root", data=ds1)
-        DataNode("subnode", data=ds2, parent=dt)
+        dt = DataTree("root", data=ds1)
+        DataTree("subnode", data=ds2, parent=dt)
 
-        expected_root = DataNode("root", data=ds1 * ds1)
-        expected_descendant = DataNode("subnode", data=ds2 * ds2, parent=expected_root)
+        expected_root = DataTree("root", data=ds1 * ds1)
+        expected_descendant = DataTree("subnode", data=ds2 * ds2, parent=expected_root)
         result = dt * dt
 
         assert_equal(result.ds, expected_root.ds)
@@ -108,15 +108,15 @@ class TestOps:
 class TestUFuncs:
     def test_root(self):
         da = xr.DataArray(name="a", data=[1, 2, 3])
-        dt = DataNode("root", data=da)
+        dt = DataTree("root", data=da)
         expected_ds = np.sin(da.to_dataset())
         result_ds = np.sin(dt).ds
         assert_equal(result_ds, expected_ds)
 
     def test_descendants(self):
         da = xr.DataArray(name="a", data=[1, 2, 3])
-        dt = DataNode("root")
-        DataNode("results", parent=dt, data=da)
+        dt = DataTree("root")
+        DataTree("results", parent=dt, data=da)
         expected_ds = np.sin(da.to_dataset())
         result_ds = np.sin(dt)["results"].ds
         assert_equal(result_ds, expected_ds)

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -3,7 +3,7 @@ import xarray as xr
 from anytree.resolver import ChildResolverError
 from xarray.testing import assert_identical
 
-from datatree import DataNode, DataTree
+from datatree import DataTree
 from datatree.io import open_datatree
 from datatree.tests import requires_netCDF4, requires_zarr
 
@@ -55,27 +55,27 @@ def create_test_datatree(modify=lambda ds: ds):
     root_data = modify(xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])}))
 
     # Avoid using __init__ so we can independently test it
-    root = DataNode(name="root", data=root_data)
-    set1 = DataNode(name="set1", parent=root, data=set1_data)
-    DataNode(name="set1", parent=set1)
-    DataNode(name="set2", parent=set1)
-    set2 = DataNode(name="set2", parent=root, data=set2_data)
-    DataNode(name="set1", parent=set2)
-    DataNode(name="set3", parent=root)
+    root = DataTree(name="root", data=root_data)
+    set1 = DataTree(name="set1", parent=root, data=set1_data)
+    DataTree(name="set1", parent=set1)
+    DataTree(name="set2", parent=set1)
+    set2 = DataTree(name="set2", parent=root, data=set2_data)
+    DataTree(name="set1", parent=set2)
+    DataTree(name="set3", parent=root)
 
     return root
 
 
 class TestStoreDatasets:
-    def test_create_datanode(self):
+    def test_create_DataTree(self):
         dat = xr.Dataset({"a": 0})
-        john = DataNode("john", data=dat)
+        john = DataTree("john", data=dat)
         assert john.ds is dat
         with pytest.raises(TypeError):
-            DataNode("mary", parent=john, data="junk")
+            DataTree("mary", parent=john, data="junk")
 
     def test_set_data(self):
-        john = DataNode("john")
+        john = DataTree("john")
         dat = xr.Dataset({"a": 0})
         john.ds = dat
         assert john.ds is dat
@@ -83,25 +83,25 @@ class TestStoreDatasets:
             john.ds = "junk"
 
     def test_has_data(self):
-        john = DataNode("john", data=xr.Dataset({"a": 0}))
+        john = DataTree("john", data=xr.Dataset({"a": 0}))
         assert john.has_data
 
-        john = DataNode("john", data=None)
+        john = DataTree("john", data=None)
         assert not john.has_data
 
 
 class TestVariablesChildrenNameCollisions:
     def test_parent_already_has_variable_with_childs_name(self):
-        dt = DataNode("root", data=xr.Dataset({"a": [0], "b": 1}))
+        dt = DataTree("root", data=xr.Dataset({"a": [0], "b": 1}))
         with pytest.raises(KeyError, match="already contains a data variable named a"):
-            DataNode("a", data=None, parent=dt)
+            DataTree("a", data=None, parent=dt)
 
         with pytest.raises(KeyError, match="already contains a data variable named a"):
-            dt.add_child(DataNode("a", data=None))
+            dt.add_child(DataTree("a", data=None))
 
     def test_assign_when_already_child_with_variables_name(self):
-        dt = DataNode("root", data=None)
-        DataNode("a", data=None, parent=dt)
+        dt = DataTree("root", data=None)
+        DataTree("a", data=None, parent=dt)
         with pytest.raises(KeyError, match="already has a child named a"):
             dt.ds = xr.Dataset({"a": 0})
 
@@ -112,82 +112,82 @@ class TestVariablesChildrenNameCollisions:
     @pytest.mark.xfail
     def test_update_when_already_child_with_variables_name(self):
         # See issue #38
-        dt = DataNode("root", data=None)
-        DataNode("a", data=None, parent=dt)
+        dt = DataTree("root", data=None)
+        DataTree("a", data=None, parent=dt)
         with pytest.raises(KeyError, match="already has a child named a"):
             dt.ds["a"] = xr.DataArray(0)
 
 
 class TestGetItems:
     def test_get_node(self):
-        folder1 = DataNode("folder1")
-        results = DataNode("results", parent=folder1)
-        highres = DataNode("highres", parent=results)
+        folder1 = DataTree("folder1")
+        results = DataTree("results", parent=folder1)
+        highres = DataTree("highres", parent=results)
         assert folder1["results"] is results
         assert folder1["results/highres"] is highres
         assert folder1[("results", "highres")] is highres
 
     def test_get_single_data_variable(self):
         data = xr.Dataset({"temp": [0, 50]})
-        results = DataNode("results", data=data)
+        results = DataTree("results", data=data)
         assert_identical(results["temp"], data["temp"])
 
     def test_get_single_data_variable_from_node(self):
         data = xr.Dataset({"temp": [0, 50]})
-        folder1 = DataNode("folder1")
-        results = DataNode("results", parent=folder1)
-        DataNode("highres", parent=results, data=data)
+        folder1 = DataTree("folder1")
+        results = DataTree("results", parent=folder1)
+        DataTree("highres", parent=results, data=data)
         assert_identical(folder1["results/highres/temp"], data["temp"])
         assert_identical(folder1[("results", "highres", "temp")], data["temp"])
 
     def test_get_nonexistent_node(self):
-        folder1 = DataNode("folder1")
-        DataNode("results", parent=folder1)
+        folder1 = DataTree("folder1")
+        DataTree("results", parent=folder1)
         with pytest.raises(ChildResolverError):
             folder1["results/highres"]
 
     def test_get_nonexistent_variable(self):
         data = xr.Dataset({"temp": [0, 50]})
-        results = DataNode("results", data=data)
+        results = DataTree("results", data=data)
         with pytest.raises(ChildResolverError):
             results["pressure"]
 
     def test_get_multiple_data_variables(self):
         data = xr.Dataset({"temp": [0, 50], "p": [5, 8, 7]})
-        results = DataNode("results", data=data)
+        results = DataTree("results", data=data)
         assert_identical(results[["temp", "p"]], data[["temp", "p"]])
 
     def test_dict_like_selection_access_to_dataset(self):
         data = xr.Dataset({"temp": [0, 50]})
-        results = DataNode("results", data=data)
+        results = DataTree("results", data=data)
         assert_identical(results[{"temp": 1}], data[{"temp": 1}])
 
 
 class TestSetItems:
     # TODO test tuple-style access too
     def test_set_new_child_node(self):
-        john = DataNode("john")
-        mary = DataNode("mary")
+        john = DataTree("john")
+        mary = DataTree("mary")
         john["/"] = mary
         assert john["mary"] is mary
 
     def test_set_new_grandchild_node(self):
-        john = DataNode("john")
-        DataNode("mary", parent=john)
-        rose = DataNode("rose")
+        john = DataTree("john")
+        DataTree("mary", parent=john)
+        rose = DataTree("rose")
         john["mary/"] = rose
         assert john["mary/rose"] is rose
 
     def test_set_new_empty_node(self):
-        john = DataNode("john")
+        john = DataTree("john")
         john["mary"] = None
         mary = john["mary"]
         assert isinstance(mary, DataTree)
         assert mary.ds is None
 
     def test_overwrite_data_in_node_with_none(self):
-        john = DataNode("john")
-        mary = DataNode("mary", parent=john, data=xr.Dataset())
+        john = DataTree("john")
+        mary = DataTree("mary", parent=john, data=xr.Dataset())
         john["mary"] = None
         assert mary.ds is None
 
@@ -197,47 +197,47 @@ class TestSetItems:
 
     def test_set_dataset_on_this_node(self):
         data = xr.Dataset({"temp": [0, 50]})
-        results = DataNode("results")
+        results = DataTree("results")
         results["/"] = data
         assert results.ds is data
 
     def test_set_dataset_as_new_node(self):
         data = xr.Dataset({"temp": [0, 50]})
-        folder1 = DataNode("folder1")
+        folder1 = DataTree("folder1")
         folder1["results"] = data
         assert folder1["results"].ds is data
 
     def test_set_dataset_as_new_node_requiring_intermediate_nodes(self):
         data = xr.Dataset({"temp": [0, 50]})
-        folder1 = DataNode("folder1")
+        folder1 = DataTree("folder1")
         folder1["results/highres"] = data
         assert folder1["results/highres"].ds is data
 
     def test_set_named_dataarray_as_new_node(self):
         data = xr.DataArray(name="temp", data=[0, 50])
-        folder1 = DataNode("folder1")
+        folder1 = DataTree("folder1")
         folder1["results"] = data
         assert_identical(folder1["results"].ds, data.to_dataset())
 
     def test_set_unnamed_dataarray(self):
         data = xr.DataArray([0, 50])
-        folder1 = DataNode("folder1")
+        folder1 = DataTree("folder1")
         with pytest.raises(ValueError, match="unable to convert"):
             folder1["results"] = data
 
     def test_add_new_variable_to_empty_node(self):
-        results = DataNode("results")
+        results = DataTree("results")
         results["/"] = xr.DataArray(name="pressure", data=[2, 3])
         assert "pressure" in results.ds
 
         # What if there is a path to traverse first?
-        results = DataNode("results")
+        results = DataTree("results")
         results["highres/"] = xr.DataArray(name="pressure", data=[2, 3])
         assert "pressure" in results["highres"].ds
 
     def test_dataarray_replace_existing_node(self):
         t = xr.Dataset({"temp": [0, 50]})
-        results = DataNode("results", data=t)
+        results = DataTree("results", data=t)
         p = xr.DataArray(name="pressure", data=[2, 3])
         results["/"] = p
         assert_identical(results.ds, p.to_dataset())
@@ -253,7 +253,7 @@ class TestTreeCreation:
 
     def test_data_in_root(self):
         dat = xr.Dataset()
-        dt = DataTree({"root": dat})
+        dt = DataTree.from_dict({"root": dat})
         assert dt.name == "root"
         assert dt.parent is None
         assert dt.children == ()
@@ -261,7 +261,7 @@ class TestTreeCreation:
 
     def test_one_layer(self):
         dat1, dat2 = xr.Dataset({"a": 1}), xr.Dataset({"b": 2})
-        dt = DataTree({"run1": dat1, "run2": dat2})
+        dt = DataTree.from_dict({"run1": dat1, "run2": dat2})
         assert dt.ds is None
         assert dt["run1"].ds is dat1
         assert dt["run1"].children == ()
@@ -270,7 +270,7 @@ class TestTreeCreation:
 
     def test_two_layers(self):
         dat1, dat2 = xr.Dataset({"a": 1}), xr.Dataset({"a": [1, 2]})
-        dt = DataTree({"highres/run": dat1, "lowres/run": dat2})
+        dt = DataTree.from_dict({"highres/run": dat1, "lowres/run": dat2})
         assert "highres" in [c.name for c in dt.children]
         assert "lowres" in [c.name for c in dt.children]
         highres_run = dt.get_node("highres/run")
@@ -300,16 +300,16 @@ class TestRestructuring:
 
 class TestRepr:
     def test_print_empty_node(self):
-        dt = DataNode("root")
+        dt = DataTree("root")
         printout = dt.__str__()
-        assert printout == "DataNode('root')"
+        assert printout == "DataTree('root')"
 
     def test_print_node_with_data(self):
         dat = xr.Dataset({"a": [0, 2]})
-        dt = DataNode("root", data=dat)
+        dt = DataTree("root", data=dat)
         printout = dt.__str__()
         expected = [
-            "DataNode('root')",
+            "DataTree('root')",
             "Dimensions",
             "Coordinates",
             "a",
@@ -321,8 +321,8 @@ class TestRepr:
 
     def test_nested_node(self):
         dat = xr.Dataset({"a": [0, 2]})
-        root = DataNode("root")
-        DataNode("results", data=dat, parent=root)
+        root = DataTree("root")
+        DataTree("results", data=dat, parent=root)
         printout = root.__str__()
         assert printout.splitlines()[2].startswith("    ")
 
@@ -335,7 +335,7 @@ class TestRepr:
 
     def test_repr_of_node_with_data(self):
         dat = xr.Dataset({"a": [0, 2]})
-        dt = DataNode("root", data=dat)
+        dt = DataTree("root", data=dat)
         assert "Coordinates" in repr(dt)
 
 

--- a/datatree/tests/test_mapping.py
+++ b/datatree/tests/test_mapping.py
@@ -16,8 +16,8 @@ class TestCheckTreesIsomorphic:
             _check_isomorphic("s", 1)
 
     def test_different_widths(self):
-        dt1 = DataTree(data_objects={"a": empty})
-        dt2 = DataTree(data_objects={"a": empty, "b": empty})
+        dt1 = DataTree.from_dict(data_objects={"a": empty})
+        dt2 = DataTree.from_dict(data_objects={"a": empty, "b": empty})
         expected_err_str = (
             "'root' in the first tree has 1 children, whereas its counterpart node 'root' in the "
             "second tree has 2 children"
@@ -26,8 +26,8 @@ class TestCheckTreesIsomorphic:
             _check_isomorphic(dt1, dt2)
 
     def test_different_heights(self):
-        dt1 = DataTree(data_objects={"a": empty})
-        dt2 = DataTree(data_objects={"a": empty, "a/b": empty})
+        dt1 = DataTree.from_dict(data_objects={"a": empty})
+        dt2 = DataTree.from_dict(data_objects={"a": empty, "a/b": empty})
         expected_err_str = (
             "'root/a' in the first tree has 0 children, whereas its counterpart node 'root/a' in the "
             "second tree has 1 children"
@@ -36,8 +36,8 @@ class TestCheckTreesIsomorphic:
             _check_isomorphic(dt1, dt2)
 
     def test_only_one_has_data(self):
-        dt1 = DataTree(data_objects={"a": xr.Dataset({"a": 0})})
-        dt2 = DataTree(data_objects={"a": None})
+        dt1 = DataTree.from_dict(data_objects={"a": xr.Dataset({"a": 0})})
+        dt2 = DataTree.from_dict(data_objects={"a": None})
         expected_err_str = (
             "'root/a' in the first tree has data, whereas its counterpart node 'root/a' in the "
             "second tree has no data"
@@ -46,8 +46,8 @@ class TestCheckTreesIsomorphic:
             _check_isomorphic(dt1, dt2)
 
     def test_names_different(self):
-        dt1 = DataTree(data_objects={"a": xr.Dataset()})
-        dt2 = DataTree(data_objects={"b": empty})
+        dt1 = DataTree.from_dict(data_objects={"a": xr.Dataset()})
+        dt2 = DataTree.from_dict(data_objects={"b": empty})
         expected_err_str = (
             "'root/a' in the first tree has name 'a', whereas its counterpart node 'root/b' in the "
             "second tree has name 'b'"
@@ -56,28 +56,28 @@ class TestCheckTreesIsomorphic:
             _check_isomorphic(dt1, dt2, require_names_equal=True)
 
     def test_isomorphic_names_equal(self):
-        dt1 = DataTree(
+        dt1 = DataTree.from_dict(
             data_objects={"a": empty, "b": empty, "b/c": empty, "b/d": empty}
         )
-        dt2 = DataTree(
+        dt2 = DataTree.from_dict(
             data_objects={"a": empty, "b": empty, "b/c": empty, "b/d": empty}
         )
         _check_isomorphic(dt1, dt2, require_names_equal=True)
 
     def test_isomorphic_ordering(self):
-        dt1 = DataTree(
+        dt1 = DataTree.from_dict(
             data_objects={"a": empty, "b": empty, "b/d": empty, "b/c": empty}
         )
-        dt2 = DataTree(
+        dt2 = DataTree.from_dict(
             data_objects={"a": empty, "b": empty, "b/c": empty, "b/d": empty}
         )
         _check_isomorphic(dt1, dt2, require_names_equal=False)
 
     def test_isomorphic_names_not_equal(self):
-        dt1 = DataTree(
+        dt1 = DataTree.from_dict(
             data_objects={"a": empty, "b": empty, "b/c": empty, "b/d": empty}
         )
-        dt2 = DataTree(
+        dt2 = DataTree.from_dict(
             data_objects={"A": empty, "B": empty, "B/C": empty, "B/D": empty}
         )
         _check_isomorphic(dt1, dt2)

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -7,18 +7,6 @@ import anytree
 PathType = Union[Hashable, Sequence[Hashable]]
 
 
-def _init_single_treenode(obj, name, parent, children):
-    if not isinstance(name, str) or "/" in name:
-        raise ValueError(f"invalid name {name}")
-    obj.name = name
-
-    obj.parent = parent
-    if children:
-        obj.children = children
-
-    return obj
-
-
 class TreeNode(anytree.NodeMixin):
     """
     Base class representing a node of a tree, with methods for traversing and altering the tree.
@@ -49,7 +37,13 @@ class TreeNode(anytree.NodeMixin):
         parent: TreeNode = None,
         children: Iterable[TreeNode] = None,
     ):
-        _init_single_treenode(self, name=name, parent=parent, children=children)
+        if not isinstance(name, str) or "/" in name:
+            raise ValueError(f"invalid name {name}")
+        self.name = name
+
+        self.parent = parent
+        if children:
+            self.children = children
 
     def __str__(self):
         """A printable representation of the structure of this entire subtree."""


### PR DESCRIPTION
This PR reorganises the constructors for a `DataTree` object, so that `DataTree.__init__` now creates a single node (making the `DataNode` shortcut obselete), whilst creating an entire tree at once from a dictionary of `path: ds` pairs can still be done via a new `from_dict` classmethod.

This is much cleaner, and prevents the testing code being filled with `DataNode()` instead of `DataTree`, but it will also break most code relying on `datatree`.

@jhamman it looks like [ndpyramid](https://github.com/carbonplan/ndpyramid) points to this repo's `main` - do you want to freeze it so that I can make more changes like this without breaking your code? I'm about to experiment with changing other things too.