### PR TITLE
Forbid .ds=None

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -106,19 +106,23 @@ class DataTree(
             raise TypeError(
                 f"{type(data)} object is not an xarray Dataset, DataArray, or None"
             )
+
         if isinstance(data, DataArray):
             data = data.to_dataset()
-        if data is not None:
-            for var in list(data.variables):
-                if var in list(c.name for c in self.children):
-                    raise KeyError(
-                        f"Cannot add variable named {var}: node already has a child named {var}"
-                    )
+        elif data is None:
+            data = Dataset()
+
+        for var in list(data.variables):
+            if var in list(c.name for c in self.children):
+                raise KeyError(
+                    f"Cannot add variable named {var}: node already has a child named {var}"
+                )
+
         self._ds = data
 
     @property
-    def has_data(self):
-        return self.ds is not None
+    def has_data(self) -> bool:
+        return len(self.ds.variables) > 0
 
     @classmethod
     def from_dict(

--- a/datatree/mapping.py
+++ b/datatree/mapping.py
@@ -17,13 +17,12 @@ def _check_isomorphic(subtree_a, subtree_b, require_names_equal=False):
     """
     Check that two trees have the same structure, raising an error if not.
 
-    Does not check the actual data in the nodes, but it does check that if one node does/doesn't have data then its
-    counterpart in the other tree also does/doesn't have data.
+    Does not compare the actual data in the nodes.
 
     Also does not check that the root nodes of each tree have the same parent - so this function checks that subtrees
     are isomorphic, not the entire tree above (if it exists).
 
-    Can optionally check if respective nodes should have the same name.
+    Can optionally check if corresponding nodes should have the same name.
 
     Parameters
     ----------
@@ -37,8 +36,8 @@ def _check_isomorphic(subtree_a, subtree_b, require_names_equal=False):
     TypeError
         If either subtree_a or subtree_b are not tree objects.
     TreeIsomorphismError
-        If subtree_a and subtree_b are tree objects, but are not isomorphic to one another, or one contains data at a
-        location the other does not. Also optionally raised if their structure is isomorphic, but the names of any two
+        If subtree_a and subtree_b are tree objects, but are not isomorphic to one another.
+        Also optionally raised if their structure is isomorphic, but the names of any two
         respective nodes are not equal.
     """
     # TODO turn this into a public function called assert_isomorphic
@@ -66,15 +65,6 @@ def _check_isomorphic(subtree_a, subtree_b, require_names_equal=False):
                     f"second tree has name '{node_b.name}'."
                 )
 
-        if node_a.has_data != node_b.has_data:
-            dat_a = "no " if not node_a.has_data else ""
-            dat_b = "no " if not node_b.has_data else ""
-            raise TreeIsomorphismError(
-                f"Trees are not isomorphic because node '{path_a}' in the first tree has "
-                f"{dat_a}data, whereas its counterpart node '{path_b}' in the second tree "
-                f"has {dat_b}data."
-            )
-
         if len(node_a.children) != len(node_b.children):
             raise TreeIsomorphismError(
                 f"Trees are not isomorphic because node '{path_a}' in the first tree has "
@@ -89,7 +79,7 @@ def map_over_subtree(func):
 
     Applies a function to every dataset in one or more subtrees, returning new trees which store the results.
 
-    The function will be applied to any dataset stored in any of the nodes in the trees. The returned trees will have
+    The function will be applied to any non-empty dataset stored in any of the nodes in the trees. The returned trees will have
     the same structure as the supplied trees.
 
     `func` needs to return one Datasets, DataArrays, or None in order to be able to rebuild the subtrees after

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -14,10 +14,7 @@ def assert_tree_equal(dt_a, dt_b):
     for a, b in zip(dt_a.subtree, dt_b.subtree):
         assert a.name == b.name
         assert a.pathstr == b.pathstr
-        if a.has_data:
-            assert a.ds.equals(b.ds)
-        else:
-            assert a.ds is b.ds
+        assert a.ds.equals(b.ds)
 
 
 def create_test_datatree(modify=lambda ds: ds):
@@ -183,17 +180,17 @@ class TestSetItems:
         john["mary"] = None
         mary = john["mary"]
         assert isinstance(mary, DataTree)
-        assert mary.ds is None
+        assert_identical(mary.ds, xr.Dataset())
 
     def test_overwrite_data_in_node_with_none(self):
         john = DataTree("john")
         mary = DataTree("mary", parent=john, data=xr.Dataset())
         john["mary"] = None
-        assert mary.ds is None
+        assert_identical(mary.ds, xr.Dataset())
 
         john.ds = xr.Dataset()
         john["/"] = None
-        assert john.ds is None
+        assert_identical(john.ds, xr.Dataset())
 
     def test_set_dataset_on_this_node(self):
         data = xr.Dataset({"temp": [0, 50]})
@@ -249,7 +246,7 @@ class TestTreeCreation:
         assert dt.name == "root"
         assert dt.parent is None
         assert dt.children == ()
-        assert dt.ds is None
+        assert_identical(dt.ds, xr.Dataset())
 
     def test_data_in_root(self):
         dat = xr.Dataset()
@@ -262,7 +259,7 @@ class TestTreeCreation:
     def test_one_layer(self):
         dat1, dat2 = xr.Dataset({"a": 1}), xr.Dataset({"b": 2})
         dt = DataTree.from_dict({"run1": dat1, "run2": dat2})
-        assert dt.ds is None
+        assert_identical(dt.ds, xr.Dataset())
         assert dt["run1"].ds is dat1
         assert dt["run1"].children == ()
         assert dt["run2"].ds is dat2

--- a/datatree/tests/test_mapping.py
+++ b/datatree/tests/test_mapping.py
@@ -35,16 +35,6 @@ class TestCheckTreesIsomorphic:
         with pytest.raises(TreeIsomorphismError, match=expected_err_str):
             _check_isomorphic(dt1, dt2)
 
-    def test_only_one_has_data(self):
-        dt1 = DataTree.from_dict(data_objects={"a": xr.Dataset({"a": 0})})
-        dt2 = DataTree.from_dict(data_objects={"a": None})
-        expected_err_str = (
-            "'root/a' in the first tree has data, whereas its counterpart node 'root/a' in the "
-            "second tree has no data"
-        )
-        with pytest.raises(TreeIsomorphismError, match=expected_err_str):
-            _check_isomorphic(dt1, dt2)
-
     def test_names_different(self):
         dt1 = DataTree.from_dict(data_objects={"a": xr.Dataset()})
         dt2 = DataTree.from_dict(data_objects={"b": empty})


### PR DESCRIPTION
Originally I had the `.ds` attribute as being either an instance of `Dataset`, or `None` to represent no data. This isn't a good idea, so this PR changes it to instead use an empty Dataset to represent no data, so `.ds` can always be relied upon to return a `Dataset` object.