### PR TITLE
Add assert_equal functions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite("datatree.testing")

--- a/datatree/__init__.py
+++ b/datatree/__init__.py
@@ -3,3 +3,4 @@
 from .datatree import DataTree
 from .io import open_datatree
 from .mapping import map_over_subtree
+from .testing import assert_equal, assert_identical, assert_isomorphic

--- a/datatree/__init__.py
+++ b/datatree/__init__.py
@@ -3,4 +3,3 @@
 from .datatree import DataTree
 from .io import open_datatree
 from .mapping import map_over_subtree
-from .testing import assert_equal, assert_identical, assert_isomorphic

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -409,7 +409,7 @@ class DataTree(
     def nbytes(self) -> int:
         return sum(node.ds.nbytes if node.has_data else 0 for node in self.subtree)
 
-    def isomorphic(self, other: DataTree) -> bool:
+    def isomorphic(self, other: DataTree, strict_names: bool = False) -> bool:
         """
         Two DataTrees are isomorphic if every node has the same number of children.
 
@@ -417,6 +417,7 @@ class DataTree(
         ----------
         other : xarray.DataTree
             The tree object to compare to.
+        strict_names : bool, default is False
 
         See Also
         --------
@@ -424,7 +425,7 @@ class DataTree(
         DataTree.identical
         """
         try:
-            _check_isomorphic(self, other, require_names_equal=False)
+            _check_isomorphic(self, other, require_names_equal=strict_names)
         except (TypeError, TreeIsomorphismError):
             return False
 
@@ -446,8 +447,6 @@ class DataTree(
         if not self.isomorphic(other):
             return False
 
-        # TODO this will raise on the first non-equal node - would it be better to print all differences?
-        # TODO this might fail for .ds=None
         return all(
             node.ds.equals(other_node.ds)
             for node, other_node in zip(self.subtree, other.subtree)
@@ -468,11 +467,9 @@ class DataTree(
         Dataset.identical
         DataTree.equals
         """
-        if not self.isomorphic(other):
+        if not self.isomorphic(other, strict_names=True):
             return False
 
-        # TODO this will raise on the first non-equal node - would it be better to print all differences?
-        # TODO this might fail for .ds=None
         return all(
             node.ds.identical(other_node.ds)
             for node, other_node in zip(self.subtree, other.subtree)

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -8,7 +8,7 @@ from xarray import DataArray, Dataset, merge
 from xarray.core import dtypes, utils
 from xarray.core.variable import Variable
 
-from .mapping import TreeIsomorphismError, _check_isomorphic, map_over_subtree
+from .mapping import TreeIsomorphismError, check_isomorphic, map_over_subtree
 from .ops import (
     DataTreeArithmeticMixin,
     MappedDatasetMethodsMixin,
@@ -425,7 +425,7 @@ class DataTree(
         DataTree.identical
         """
         try:
-            _check_isomorphic(self, other, require_names_equal=strict_names)
+            check_isomorphic(self, other, require_names_equal=strict_names)
         except (TypeError, TreeIsomorphismError):
             return False
 

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -446,6 +446,7 @@ class DataTree(
                 require_names_equal=strict_names,
                 check_from_root=from_root,
             )
+            return True
         except (TypeError, TreeIsomorphismError):
             return False
 
@@ -474,8 +475,10 @@ class DataTree(
             return False
 
         return all(
-            node.ds.equals(other_node.ds)
-            for node, other_node in zip(self.subtree, other.subtree)
+            [
+                node.ds.equals(other_node.ds)
+                for node, other_node in zip(self.subtree, other.subtree)
+            ]
         )
 
     def identical(self, other: DataTree, from_root=True) -> bool:

--- a/datatree/formatting.py
+++ b/datatree/formatting.py
@@ -1,14 +1,52 @@
-from xarray.core.formatting import diff_dataset_repr
+from xarray.core.formatting import _compat_to_str, diff_dataset_repr
 
-from .mapping import _check_isomorphic
+from .mapping import TreeIsomorphismError, _check_isomorphic
 
 
-def diff_node_repr(a, b, compat, path):
-    dataset_diff_repr = diff_dataset_repr(a, b, compat)
-    return f"Nodes at position {path} do not match:\n".join(dataset_diff_repr)
+def diff_treestructure_summary(a, b, compat):
+    try:
+        _check_isomorphic(
+            a, b, require_names_equal=True if compat == "identical" else False
+        )
+    except (TreeIsomorphismError, TypeError) as err:
+        diff = str(err)
+        return diff
+    else:
+        return ""
+
+
+def diff_nodewise_summary(a, b, compat):
+    """Iterates over all corresponding nodes, recording differences between data at each location."""
+
+    summary = []
+    for node_a, node_b in zip(a.subtree, b.subtree):
+        a_ds, b_ds = node_a.ds, node_b.ds
+
+        if not a_ds._all_compat(b_ds, compat):
+            path = node_a.pathstr
+            nodediff = (
+                f"Data in nodes at position {path} do not match:\n"
+                f"{diff_dataset_repr(a, b, compat)}"
+            )
+            summary.append(nodediff)
+
+    return "\n".join(summary)
 
 
 def diff_tree_repr(a, b, compat):
+    summary = [
+        f"Left and right {type(a).__name__} objects are not {_compat_to_str(compat)}"
+    ]
 
-    # TODO get the string error message somehow
-    _check_isomorphic(a, b, require_names_equal=True if compat is "identical" else False)
+    # TODO check root parents?
+
+    treestructure_diff = diff_treestructure_summary(a, b, compat)
+
+    # If the trees structures are different there is no point comparing each node
+    if treestructure_diff or compat == "isomorphic":
+        summary.append(treestructure_diff)
+    else:
+        nodewise_diff = diff_nodewise_summary(a, b, compat)
+        summary.append(nodewise_diff)
+
+    return "\n".join(summary)

--- a/datatree/formatting.py
+++ b/datatree/formatting.py
@@ -1,0 +1,14 @@
+from xarray.core.formatting import diff_dataset_repr
+
+from .mapping import _check_isomorphic
+
+
+def diff_node_repr(a, b, compat, path):
+    dataset_diff_repr = diff_dataset_repr(a, b, compat)
+    return f"Nodes at position {path} do not match:\n".join(dataset_diff_repr)
+
+
+def diff_tree_repr(a, b, compat):
+
+    # TODO get the string error message somehow
+    _check_isomorphic(a, b, require_names_equal=True if compat is "identical" else False)

--- a/datatree/formatting.py
+++ b/datatree/formatting.py
@@ -1,18 +1,6 @@
 from xarray.core.formatting import _compat_to_str, diff_dataset_repr
 
-from .mapping import TreeIsomorphismError, _check_isomorphic
-
-
-def diff_treestructure_summary(a, b, compat):
-    try:
-        _check_isomorphic(
-            a, b, require_names_equal=True if compat == "identical" else False
-        )
-    except (TreeIsomorphismError, TypeError) as err:
-        diff = str(err)
-        return diff
-    else:
-        return ""
+from .mapping import diff_treestructure
 
 
 def diff_nodewise_summary(a, b, compat):
@@ -40,9 +28,12 @@ def diff_tree_repr(a, b, compat):
 
     # TODO check root parents?
 
-    treestructure_diff = diff_treestructure_summary(a, b, compat)
+    treestructure_diff = diff_treestructure(
+        a, b, True if compat == "identical" else False
+    )
 
     # If the trees structures are different there is no point comparing each node
+    # TODO we could show any differences in nodes up to the first place that structure differs?
     if treestructure_diff or compat == "isomorphic":
         summary.append(treestructure_diff)
     else:

--- a/datatree/formatting.py
+++ b/datatree/formatting.py
@@ -6,15 +6,19 @@ from .mapping import diff_treestructure
 def diff_nodewise_summary(a, b, compat):
     """Iterates over all corresponding nodes, recording differences between data at each location."""
 
+    compat_str = _compat_to_str(compat)
+
     summary = []
     for node_a, node_b in zip(a.subtree, b.subtree):
         a_ds, b_ds = node_a.ds, node_b.ds
 
         if not a_ds._all_compat(b_ds, compat):
             path = node_a.pathstr
+            dataset_diff = diff_dataset_repr(a_ds, b_ds, compat_str)
+            data_diff = "\n".join(dataset_diff.split("\n", 1)[1:])
+
             nodediff = (
-                f"Data in nodes at position {path} do not match:\n"
-                f"{diff_dataset_repr(a, b, compat)}"
+                f"\nData in nodes at position '{path}' do not match:" f"{data_diff}"
             )
             summary.append(nodediff)
 
@@ -28,16 +32,15 @@ def diff_tree_repr(a, b, compat):
 
     # TODO check root parents?
 
-    treestructure_diff = diff_treestructure(
-        a, b, True if compat == "identical" else False
-    )
+    strict_names = True if compat in ["equals", "identical"] else False
+    treestructure_diff = diff_treestructure(a, b, strict_names)
 
     # If the trees structures are different there is no point comparing each node
     # TODO we could show any differences in nodes up to the first place that structure differs?
     if treestructure_diff or compat == "isomorphic":
-        summary.append(treestructure_diff)
+        summary.append("\n" + treestructure_diff)
     else:
         nodewise_diff = diff_nodewise_summary(a, b, compat)
-        summary.append(nodewise_diff)
+        summary.append("\n" + nodewise_diff)
 
     return "\n".join(summary)

--- a/datatree/mapping.py
+++ b/datatree/mapping.py
@@ -41,7 +41,6 @@ def _check_isomorphic(subtree_a, subtree_b, require_names_equal=False):
         location the other does not. Also optionally raised if their structure is isomorphic, but the names of any two
         respective nodes are not equal.
     """
-    # TODO turn this into a public function called assert_isomorphic
 
     if not isinstance(subtree_a, TreeNode):
         raise TypeError(

--- a/datatree/testing.py
+++ b/datatree/testing.py
@@ -1,6 +1,5 @@
 from xarray.testing import ensure_warnings
 
-
 from .datatree import DataTree
 from .formatting import diff_tree_repr
 
@@ -78,6 +77,6 @@ def assert_identical(a: DataTree, b: DataTree):
     __tracebackhide__ = True
     assert type(a) == type(b)
     if isinstance(a, DataTree):
-        assert a.identical(b), diff_tree_repr(a, b, "identical")
+        assert a.equals(b), diff_tree_repr(a, b, "identical")
     else:
         raise TypeError(f"{type(a)} not of type DataTree")

--- a/datatree/testing.py
+++ b/datatree/testing.py
@@ -1,0 +1,83 @@
+from xarray.testing import ensure_warnings
+
+
+from .datatree import DataTree
+from .formatting import diff_tree_repr
+
+
+@ensure_warnings
+def assert_isomorphic(a: DataTree, b: DataTree):
+    """
+    Two DataTrees are isomorphic if every node has the same number of children.
+
+    Parameters
+    ----------
+    a : xarray.DataTree
+        The first object to compare.
+    b : xarray.DataTree
+        The second object to compare.
+
+    See Also
+    --------
+    DataTree.equals
+    DataTree.identical
+    """
+    __tracebackhide__ = True
+    assert type(a) == type(b)
+    if isinstance(a, DataTree):
+        assert a.isomorphic(b), diff_tree_repr(a, b, "isomorphic")
+    else:
+        raise TypeError(f"{type(a)} not of type DataTree")
+
+
+@ensure_warnings
+def assert_equal(a: DataTree, b: DataTree):
+    """
+    Two DataTrees are equal if they have isomorphic node structures, and
+    all stored Datasets are equal.
+
+    Parameters
+    ----------
+    a : xarray.DataTree
+        The first object to compare.
+    b : xarray.DataTree
+        The second object to compare.
+
+    See Also
+    --------
+    Dataset.equals
+    DataTree.identical
+    """
+    __tracebackhide__ = True
+    assert type(a) == type(b)
+    if isinstance(a, DataTree):
+        assert a.equals(b), diff_tree_repr(a, b, "equals")
+    else:
+        raise TypeError(f"{type(a)} not of type DataTree")
+
+
+@ensure_warnings
+def assert_identical(a: DataTree, b: DataTree):
+    """
+    Like equals, but also checks all corresponding nodes have the same names, as well as
+    all dataset attributes and the attributes on all variables and coordinates.
+
+    Parameters
+    ----------
+    a : xarray.DataTree
+        The first object to compare.
+    b : xarray.DataTree
+        The second object to compare.
+
+    See Also
+    --------
+    Dataset.identical
+    DataTree.equals
+    """
+
+    __tracebackhide__ = True
+    assert type(a) == type(b)
+    if isinstance(a, DataTree):
+        assert a.identical(b), diff_tree_repr(a, b, "identical")
+    else:
+        raise TypeError(f"{type(a)} not of type DataTree")

--- a/datatree/testing.py
+++ b/datatree/testing.py
@@ -77,6 +77,6 @@ def assert_identical(a: DataTree, b: DataTree):
     __tracebackhide__ = True
     assert type(a) == type(b)
     if isinstance(a, DataTree):
-        assert a.equals(b), diff_tree_repr(a, b, "identical")
+        assert a.identical(b), diff_tree_repr(a, b, "identical")
     else:
         raise TypeError(f"{type(a)} not of type DataTree")

--- a/datatree/testing.py
+++ b/datatree/testing.py
@@ -5,61 +5,91 @@ from .formatting import diff_tree_repr
 
 
 @ensure_warnings
-def assert_isomorphic(a: DataTree, b: DataTree):
+def assert_isomorphic(a: DataTree, b: DataTree, from_root: bool = False):
     """
-    Two DataTrees are isomorphic if every node has the same number of children.
+    Two DataTrees are considered isomorphic if every node has the same number of children.
+
+    Nothing about the data in each node is checked.
+
+    Isomorphism is a necessary condition for two trees to be used in a nodewise binary operation,
+    such as tree1 + tree2.
+
+    By default this function does not check any part of the tree above the given node.
+    Therefore this function can be used as default to check that two subtrees are isomorphic.
 
     Parameters
     ----------
-    a : xarray.DataTree
+    a : DataTree
         The first object to compare.
-    b : xarray.DataTree
+    b : DataTree
         The second object to compare.
+    from_root : bool, optional, default is False
+        Whether or not to first traverse to the root of the trees before checking for isomorphism.
+        If a & b have no parents then this has no effect.
 
     See Also
     --------
-    DataTree.equals
-    DataTree.identical
+    DataTree.isomorphic
+    assert_equals
+    assert_identical
     """
     __tracebackhide__ = True
     assert type(a) == type(b)
+
     if isinstance(a, DataTree):
-        assert a.isomorphic(b), diff_tree_repr(a, b, "isomorphic")
+        if from_root:
+            a = a.root
+            b = b.root
+
+        assert a.isomorphic(b, from_root=False), diff_tree_repr(a, b, "isomorphic")
     else:
         raise TypeError(f"{type(a)} not of type DataTree")
 
 
 @ensure_warnings
-def assert_equal(a: DataTree, b: DataTree):
+def assert_equal(a: DataTree, b: DataTree, from_root: bool = True):
     """
-    Two DataTrees are equal if they have isomorphic node structures, and
-    all stored Datasets are equal.
+    Two DataTrees are equal if they have isomorphic node structures, with matching node names,
+    and if they have matching variables and coordinates, all of which are equal.
+
+    By default this method will check the whole tree above the given node.
 
     Parameters
     ----------
-    a : xarray.DataTree
+    a : DataTree
         The first object to compare.
-    b : xarray.DataTree
+    b : DataTree
         The second object to compare.
+    from_root : bool, optional, default is True
+        Whether or not to first traverse to the root of the trees before checking for isomorphism.
+        If a & b have no parents then this has no effect.
 
     See Also
     --------
-    Dataset.equals
-    DataTree.identical
+    DataTree.equals
+    assert_isomorphic
+    assert_identical
     """
     __tracebackhide__ = True
     assert type(a) == type(b)
+
     if isinstance(a, DataTree):
+        if from_root:
+            a = a.root
+            b = b.root
+
         assert a.equals(b), diff_tree_repr(a, b, "equals")
     else:
         raise TypeError(f"{type(a)} not of type DataTree")
 
 
 @ensure_warnings
-def assert_identical(a: DataTree, b: DataTree):
+def assert_identical(a: DataTree, b: DataTree, from_root: bool = True):
     """
-    Like equals, but also checks all corresponding nodes have the same names, as well as
-    all dataset attributes and the attributes on all variables and coordinates.
+    Like assert_equals, but will also check all dataset attributes and the attributes on
+    all variables and coordinates.
+
+    By default this method will check the whole tree above the given node.
 
     Parameters
     ----------
@@ -67,16 +97,24 @@ def assert_identical(a: DataTree, b: DataTree):
         The first object to compare.
     b : xarray.DataTree
         The second object to compare.
+    from_root : bool, optional, default is True
+        Whether or not to first traverse to the root of the trees before checking for isomorphism.
+        If a & b have no parents then this has no effect.
 
     See Also
     --------
-    Dataset.identical
-    DataTree.equals
+    DataTree.identical
+    assert_isomorphic
+    assert_equal
     """
 
     __tracebackhide__ = True
     assert type(a) == type(b)
     if isinstance(a, DataTree):
+        if from_root:
+            a = a.root
+            b = b.root
+
         assert a.identical(b), diff_tree_repr(a, b, "identical")
     else:
         raise TypeError(f"{type(a)} not of type DataTree")

--- a/datatree/tests/test_formatting.py
+++ b/datatree/tests/test_formatting.py
@@ -1,0 +1,63 @@
+from textwrap import dedent
+
+from xarray import Dataset
+
+from datatree import DataTree
+from datatree.formatting import diff_tree_repr
+
+
+class TestDiffFormatting:
+    def test_diff_structure(self):
+        dt_1 = DataTree.from_dict({"a": None, "a/b": None, "a/c": None})
+        dt_2 = DataTree.from_dict({"d": None, "d/e": None})
+
+        expected = dedent(
+            """\
+        Left and right DataTree objects are not isomorphic
+
+        Number of children on node 'root/a' of the left object: 2
+        Number of children on node 'root/d' of the right object: 1"""
+        )
+        actual = diff_tree_repr(dt_1, dt_2, "isomorphic")
+        assert actual == expected
+
+    def test_diff_node_names(self):
+        dt_1 = DataTree.from_dict({"a": None})
+        dt_2 = DataTree.from_dict({"b": None})
+
+        expected = dedent(
+            """\
+        Left and right DataTree objects are not identical
+
+        Node 'root/a' in the left object has name 'a'
+        Node 'root/b' in the right object has name 'b'"""
+        )
+        actual = diff_tree_repr(dt_1, dt_2, "identical")
+        assert actual == expected
+
+    def test_diff_node_data(self):
+        ds1 = Dataset({"u": 0, "v": 1})
+        ds3 = Dataset({"w": 5})
+        dt_1 = DataTree.from_dict({"a": ds1, "a/b": ds3})
+        ds2 = Dataset({"u": 0})
+        ds4 = Dataset({"w": 6})
+        dt_2 = DataTree.from_dict({"a": ds2, "a/b": ds4})
+
+        expected = dedent(
+            """\
+        Left and right DataTree objects are not equal
+
+
+        Data in nodes at position 'root/a' do not match:
+
+        Data variables only on the left object:
+            v        int64 1
+
+        Data in nodes at position 'root/a/b' do not match:
+
+        Differing data variables:
+        L   w        int64 5
+        R   w        int64 6"""
+        )
+        actual = diff_tree_repr(dt_1, dt_2, "equals")
+        assert actual == expected

--- a/datatree/tests/test_mapping.py
+++ b/datatree/tests/test_mapping.py
@@ -79,6 +79,13 @@ class TestCheckTreesIsomorphic:
         with pytest.raises(TreeIsomorphismError, match="root/set1/set2"):
             check_isomorphic(dt1, dt2)
 
+    def test_checking_from_root(self):
+        dt1 = create_test_datatree()
+        dt2 = create_test_datatree()
+        dt1.parent = DataTree(name="real_root")
+        with pytest.raises(TreeIsomorphismError):
+            check_isomorphic(dt1, dt2, check_from_root=True)
+
 
 class TestMapOverSubTree:
     def test_no_trees_passed(self):

--- a/datatree/tests/test_mapping.py
+++ b/datatree/tests/test_mapping.py
@@ -2,7 +2,7 @@ import pytest
 import xarray as xr
 
 from datatree.datatree import DataTree
-from datatree.mapping import TreeIsomorphismError, _check_isomorphic, map_over_subtree
+from datatree.mapping import TreeIsomorphismError, check_isomorphic, map_over_subtree
 from datatree.treenode import TreeNode
 
 from .test_datatree import assert_tree_equal, create_test_datatree
@@ -13,37 +13,37 @@ empty = xr.Dataset()
 class TestCheckTreesIsomorphic:
     def test_not_a_tree(self):
         with pytest.raises(TypeError, match="not a tree"):
-            _check_isomorphic("s", 1)
+            check_isomorphic("s", 1)
 
     def test_different_widths(self):
         dt1 = DataTree.from_dict(data_objects={"a": empty})
-        dt2 = DataTree.from_dict(data_objects={"a": empty, "b": empty})
+        dt2 = DataTree.from_dict(data_objects={"b": empty, "c": empty})
         expected_err_str = (
-            "'root' in the first tree has 1 children, whereas its counterpart node 'root' in the "
-            "second tree has 2 children"
+            "Number of children on node 'root' of the left object: 1\n"
+            "Number of children on node 'root' of the right object: 2"
         )
         with pytest.raises(TreeIsomorphismError, match=expected_err_str):
-            _check_isomorphic(dt1, dt2)
+            check_isomorphic(dt1, dt2)
 
     def test_different_heights(self):
         dt1 = DataTree.from_dict(data_objects={"a": empty})
-        dt2 = DataTree.from_dict(data_objects={"a": empty, "a/b": empty})
+        dt2 = DataTree.from_dict(data_objects={"b": empty, "b/c": empty})
         expected_err_str = (
-            "'root/a' in the first tree has 0 children, whereas its counterpart node 'root/a' in the "
-            "second tree has 1 children"
+            "Number of children on node 'root/a' of the left object: 0\n"
+            "Number of children on node 'root/b' of the right object: 1"
         )
         with pytest.raises(TreeIsomorphismError, match=expected_err_str):
-            _check_isomorphic(dt1, dt2)
+            check_isomorphic(dt1, dt2)
 
     def test_names_different(self):
         dt1 = DataTree.from_dict(data_objects={"a": xr.Dataset()})
         dt2 = DataTree.from_dict(data_objects={"b": empty})
         expected_err_str = (
-            "'root/a' in the first tree has name 'a', whereas its counterpart node 'root/b' in the "
-            "second tree has name 'b'"
+            "Node 'root/a' in the left object has name 'a'\n"
+            "Node 'root/b' in the right object has name 'b'"
         )
         with pytest.raises(TreeIsomorphismError, match=expected_err_str):
-            _check_isomorphic(dt1, dt2, require_names_equal=True)
+            check_isomorphic(dt1, dt2, require_names_equal=True)
 
     def test_isomorphic_names_equal(self):
         dt1 = DataTree.from_dict(
@@ -52,7 +52,7 @@ class TestCheckTreesIsomorphic:
         dt2 = DataTree.from_dict(
             data_objects={"a": empty, "b": empty, "b/c": empty, "b/d": empty}
         )
-        _check_isomorphic(dt1, dt2, require_names_equal=True)
+        check_isomorphic(dt1, dt2, require_names_equal=True)
 
     def test_isomorphic_ordering(self):
         dt1 = DataTree.from_dict(
@@ -61,7 +61,7 @@ class TestCheckTreesIsomorphic:
         dt2 = DataTree.from_dict(
             data_objects={"a": empty, "b": empty, "b/c": empty, "b/d": empty}
         )
-        _check_isomorphic(dt1, dt2, require_names_equal=False)
+        check_isomorphic(dt1, dt2, require_names_equal=False)
 
     def test_isomorphic_names_not_equal(self):
         dt1 = DataTree.from_dict(
@@ -70,14 +70,14 @@ class TestCheckTreesIsomorphic:
         dt2 = DataTree.from_dict(
             data_objects={"A": empty, "B": empty, "B/C": empty, "B/D": empty}
         )
-        _check_isomorphic(dt1, dt2)
+        check_isomorphic(dt1, dt2)
 
     def test_not_isomorphic_complex_tree(self):
         dt1 = create_test_datatree()
         dt2 = create_test_datatree()
         dt2.set_node("set1/set2", TreeNode("set3"))
         with pytest.raises(TreeIsomorphismError, match="root/set1/set2"):
-            _check_isomorphic(dt1, dt2)
+            check_isomorphic(dt1, dt2)
 
 
 class TestMapOverSubTree:


### PR DESCRIPTION
Adds assert functions and methods, fixing #27.

Includes an `assert_isomorphic` for when you want to assert that two trees have corresponding structures but don't want to check any of the data in the nodes.

I should add `assert_allclose` too, and still needs tests.

Once this works I will change all the existing tests to use `assert_identical`.