### PR TITLE
fix bug where zarr's consolidated metadata is created after writing each group

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -577,7 +577,9 @@ class DataTree(
             **kwargs,
         )
 
-    def to_zarr(self, store, mode: str = "w", encoding=None, **kwargs):
+    def to_zarr(
+        self, store, mode: str = "w", encoding=None, consolidated: bool = True, **kwargs
+    ):
         """
         Write datatree contents to a Zarr store.
 
@@ -595,6 +597,9 @@ class DataTree(
             variable specific encodings as values, e.g.,
             ``{"root/set1": {"my_variable": {"dtype": "int16", "scale_factor": 0.1}, ...}, ...}``.
             See ``xarray.Dataset.to_zarr`` for available options.
+        consolidated : bool
+            If True, apply zarr's `consolidate_metadata` function to the store
+            after writing metadata for all groups.
         kwargs :
             Additional keyword arguments to be passed to ``xarray.Dataset.to_zarr``
         """
@@ -605,6 +610,7 @@ class DataTree(
             store,
             mode=mode,
             encoding=encoding,
+            consolidated=consolidated,
             **kwargs,
         )
 

--- a/datatree/io.py
+++ b/datatree/io.py
@@ -191,7 +191,16 @@ def _create_empty_zarr_group(store, group, mode):
     root.create_group(group, overwrite=True)
 
 
-def _datatree_to_zarr(dt: DataTree, store, mode: str = "w", encoding=None, **kwargs):
+def _datatree_to_zarr(
+    dt: DataTree,
+    store,
+    mode: str = "w",
+    encoding=None,
+    consolidated: bool = True,
+    **kwargs,
+):
+
+    from zarr.convenience import consolidate_metadata
 
     if kwargs.get("group", None) is not None:
         raise NotImplementedError(
@@ -215,7 +224,11 @@ def _datatree_to_zarr(dt: DataTree, store, mode: str = "w", encoding=None, **kwa
                 group=group_path,
                 mode=mode,
                 encoding=_maybe_extract_group_kwargs(encoding, dt.pathstr),
+                consolidated=False,
                 **kwargs,
             )
         if "w" in mode:
             mode = "a"
+
+    if consolidated:
+        consolidate_metadata(store)

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -358,3 +358,18 @@ class TestIO:
 
         roundtrip_dt = open_datatree(filepath, engine="zarr")
         assert_tree_equal(original_dt, roundtrip_dt)
+
+    @requires_zarr
+    def test_to_zarr_not_consolidated(self, tmpdir):
+        filepath = tmpdir / "test.zarr"
+        zmetadata = filepath / ".zmetadata"
+        s1zmetadata = filepath / "set1" / ".zmetadata"
+        filepath = str(filepath)  # casting to str avoids a pathlib bug in xarray
+        original_dt = create_test_datatree()
+        original_dt.to_zarr(filepath, consolidated=False)
+        assert not zmetadata.exists()
+        assert not s1zmetadata.exists()
+
+        with pytest.warns(RuntimeWarning, match="consolidated"):
+            roundtrip_dt = open_datatree(filepath, engine="zarr")
+        assert_tree_equal(original_dt, roundtrip_dt)


### PR DESCRIPTION
This fixes a bug where the Zarr's consolidated metadata is computed after each group's write, rather than once at the end.